### PR TITLE
feature: show correct answer after game over

### DIFF
--- a/NumRush.py
+++ b/NumRush.py
@@ -104,7 +104,7 @@ def newGameAnimation(mainGame):
             fpsClock.tick(FPS)
 
 
-def ggAnimation(strin, score, hscore, mainGame):
+def ggAnimation(strin, n, score, hscore, mainGame):
     flicker = 0
     while mainGame.running:
         flicker += 1
@@ -117,7 +117,7 @@ def ggAnimation(strin, score, hscore, mainGame):
         DISPLAYSURF.blit(texSurfaceObj, texRectObj)
         texSurfaceObj = fontObj.render(
             _("The correct answer was %s %d" ) % 
-            (strin[2:],eval(strin[2:-1])), True, RED)
+            (strin[2:],n), True, RED)
         texRectObj = texSurfaceObj.get_rect()
         texRectObj.center = (ResX // 2, ResY // 2 - 100)
         DISPLAYSURF.blit(texSurfaceObj, texRectObj)
@@ -331,7 +331,7 @@ class numrush():
                 else:
                     if(self.score > self.hscore):
                         self.hscore = self.score
-                    ggAnimation(self.strin, self.score, self.hscore, self)
+                    ggAnimation(self.strin, self.n, self.score, self.hscore, self)
                     newGameAnimation(self)
                     self.score = 0
                     speed = ResY // 320

--- a/NumRush.py
+++ b/NumRush.py
@@ -104,7 +104,7 @@ def newGameAnimation(mainGame):
             fpsClock.tick(FPS)
 
 
-def ggAnimation(score, hscore, mainGame):
+def ggAnimation(strin, score, hscore, mainGame):
     flicker = 0
     while mainGame.running:
         flicker += 1
@@ -114,6 +114,12 @@ def ggAnimation(score, hscore, mainGame):
         texSurfaceObj = megaFont.render(_("GAME OVER!"), True, DarkColor)
         texRectObj = texSurfaceObj.get_rect()
         texRectObj.center = (ResX // 2, ResY // 2)
+        DISPLAYSURF.blit(texSurfaceObj, texRectObj)
+        texSurfaceObj = fontObj.render(
+            _("The correct answer was %s %d" ) % 
+            (strin[2:],eval(strin[2:-1])), True, RED)
+        texRectObj = texSurfaceObj.get_rect()
+        texRectObj.center = (ResX // 2, ResY // 2 - 100)
         DISPLAYSURF.blit(texSurfaceObj, texRectObj)
         texSurfaceObj = megaFont.render(
             _("You Scored = %d") %
@@ -325,7 +331,7 @@ class numrush():
                 else:
                     if(self.score > self.hscore):
                         self.hscore = self.score
-                    ggAnimation(self.score, self.hscore, self)
+                    ggAnimation(self.strin, self.score, self.hscore, self)
                     newGameAnimation(self)
                     self.score = 0
                     speed = ResY // 320


### PR DESCRIPTION
## Overview
Added text in the game over splash screen after the player loses a game to show the correct answer to the question which they answered incorrectly


## Screenshots
![WhatsApp Image 2023-02-03 at 17 16 53](https://user-images.githubusercontent.com/114365550/216595796-4e83eee0-d51d-472e-af9e-64f1a2f4db06.jpg)
Before the new feature

![WhatsApp Image 2023-02-03 at 17 10 28](https://user-images.githubusercontent.com/114365550/216595882-625802ad-18e7-4edc-ab92-674aa854c697.jpg)
Displaying correct answer after adding the feature

![WhatsApp Image 2023-02-03 at 17 12 06](https://user-images.githubusercontent.com/114365550/216596051-35e3ee90-8128-422b-ab2b-f19775cc6a0e.jpg)
Displaying correct answer after adding the feature

![WhatsApp Image 2023-02-03 at 17 14 40](https://user-images.githubusercontent.com/114365550/216596127-decb7442-741b-4628-ab1c-ca742d9b9743.jpg)
Displaying correct answer after adding the feature

![WhatsApp Image 2023-02-03 at 17 11 03](https://user-images.githubusercontent.com/114365550/216597265-9d6fc9f9-875c-4dec-a8a4-6609b860eca0.jpg)
Displaying correct answer after adding the feature

## Tests
I have tried all four possible operations as shown in the screenshots and played the game besides that with my commits as well and have not encountered any bugs.


## Changes
```
def ggAnimation(strin, score, hscore, mainGame):
```
> line 107 : strin was added as a parameter to use it to later evaluate and display the strin (strin holds the current question)


```
        texSurfaceObj = fontObj.render(
            _("The correct answer was %s %d" ) % 
            (strin[2:],eval(strin[2:-1])), True, RED)
        texRectObj = texSurfaceObj.get_rect()
        texRectObj.center = (ResX // 2, ResY // 2 - 100)
        DISPLAYSURF.blit(texSurfaceObj, texRectObj)
```
> line 118 to 123 : implements the actual functionality of calculating and displaying the correct answer


```
                    ggAnimation(self.strin, self.score, self.hscore, self)
```
> line 324 : Calls the ggAnimation function with the newly added strin parameter included